### PR TITLE
Add directory contents capture to ls_output.txt

### DIFF
--- a/ls_output.txt
+++ b/ls_output.txt
@@ -1,0 +1,1 @@
+ls_output.txt


### PR DESCRIPTION
## Overview
This PR implements functionality to capture and store the directory contents of `/projects/sandbox/lolz` for reference and documentation purposes.

## Requirements Implemented
- Execute the 'ls' command in the /projects/sandbox/lolz directory
- Capture the command output
- Write the output to a file named 'ls_output.txt' in the repository root

## Changes Made
- **Added**: `ls_output.txt` - Contains the output of the `ls` command showing the directory contents

## Technical Details
- The ls command was executed in the `/projects/sandbox/lolz` directory
- Output was captured and written to `ls_output.txt` at the repository root
- File is version controlled for future reference

## Testing
- Verified that `ls_output.txt` was created successfully
- Confirmed the file contains the expected directory listing output